### PR TITLE
Implement signal generator filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .cache
+tests/test_core_filter
+tests/test_signal_gen

--- a/bpipe/signal_gen.c
+++ b/bpipe/signal_gen.c
@@ -1,0 +1,54 @@
+#include "signal_gen.h"
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+static inline float fracf(float x)
+{
+    return x - floorf(x);
+}
+
+void BpSignalGenTransform(Bp_Filter_t* filt, Bp_Batch_t *input_batch, Bp_Batch_t *output_batch)
+{
+    (void)input_batch;
+    Bp_SignalGen_t* gen = (Bp_SignalGen_t*)filt;
+
+    size_t space = output_batch->capacity - output_batch->head;
+    float *dst_f = (float*)output_batch->data; /* may cast for computation */
+    unsigned *dst_u = (unsigned*)output_batch->data;
+
+    for(size_t i=0; i<space; ++i){
+        float ph = gen->phase + gen->frequency * gen->sample_idx;
+        float val = 0.0f;
+        switch(gen->waveform){
+            case BP_WAVE_SQUARE:
+                val = fracf(ph) < 0.5f ? gen->amplitude : -gen->amplitude;
+                break;
+            case BP_WAVE_SINE:
+                val = gen->amplitude * sinf(2.0f * (float)M_PI * ph);
+                break;
+            case BP_WAVE_TRIANGLE: {
+                float fr = fracf(ph);
+                val = gen->amplitude * (4.0f * fabsf(fr - 0.5f) - 1.0f);
+                break;
+            }
+            case BP_WAVE_SAWTOOTH:
+            default: {
+                float fr = fracf(ph);
+                val = gen->amplitude * fr;
+                break;
+            }
+        }
+        val += gen->x_offset;
+        if(filt->dtype == DTYPE_UNSIGNED){
+            dst_u[output_batch->head] = (unsigned)val;
+        } else if(filt->dtype == DTYPE_INT){
+            ((int*)output_batch->data)[output_batch->head] = (int)val;
+        } else {
+            dst_f[output_batch->head] = val;
+        }
+        output_batch->head++;
+        gen->sample_idx++;
+    }
+}

--- a/bpipe/signal_gen.h
+++ b/bpipe/signal_gen.h
@@ -1,0 +1,25 @@
+#ifndef BPIPE_SIGNAL_GEN_H
+#define BPIPE_SIGNAL_GEN_H
+
+#include "core.h"
+
+typedef enum {
+    BP_WAVE_SQUARE = 0,
+    BP_WAVE_SINE,
+    BP_WAVE_TRIANGLE,
+    BP_WAVE_SAWTOOTH
+} BpWaveform_t;
+
+typedef struct {
+    Bp_Filter_t base;
+    BpWaveform_t waveform;
+    float frequency;    /* cycles per sample */
+    float phase;        /* initial phase offset in cycles */
+    float amplitude;
+    float x_offset;
+    unsigned long sample_idx;
+} Bp_SignalGen_t;
+
+void BpSignalGenTransform(Bp_Filter_t* filt, Bp_Batch_t *input_batch, Bp_Batch_t *output_batch);
+
+#endif /* BPIPE_SIGNAL_GEN_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,17 +1,28 @@
 CC = gcc
 CFLAGS = -I../ -std=c99 -Wall -Werror -pthread
-LDFLAGS = -pthread
+LDFLAGS = -pthread -lm
 
-SRC = ../bpipe/core.c
-TEST = test_core_filter.c
+SRC = ../bpipe/core.c ../bpipe/signal_gen.c
 
-all: test_core_filter
+all: test_core_filter test_signal_gen
 
-test_core_filter: $(SRC) $(TEST)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
+# existing test
+TEST_CORE = test_core_filter.c
 
-run: test_core_filter
+test_core_filter: $(SRC) $(TEST_CORE)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+# new generator test
+TEST_GEN = test_signal_gen.c
+
+test_signal_gen: $(SRC) $(TEST_GEN)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+run_core: test_core_filter
 	./test_core_filter
 
+run_gen: test_signal_gen
+	./test_signal_gen
+
 clean:
-	rm -f test_core_filter
+	rm -f test_core_filter test_signal_gen

--- a/tests/test_signal_gen.c
+++ b/tests/test_signal_gen.c
@@ -1,0 +1,71 @@
+#include "../bpipe/signal_gen.h"
+#include "unity.h"
+#include <stdlib.h>
+#include <string.h>
+
+static void init_pass_through(Bp_Filter_t* f)
+{
+    memset(f, 0, sizeof(*f));
+    f->transform = BpPassThroughTransform;
+    f->ring_capacity_expo = 4;
+    f->batch_capacity_expo = 6;
+    f->dtype = DTYPE_UNSIGNED;
+    f->data_width = sizeof(unsigned);
+    f->modulo_mask = (1u << f->ring_capacity_expo) - 1u;
+    f->has_input_buffer = true;
+    pthread_mutex_init(&f->cond_mutex, NULL);
+    pthread_cond_init(&f->cond_not_full, NULL);
+    pthread_cond_init(&f->cond_not_empty, NULL);
+    Bp_allocate_buffers(f);
+}
+
+static void free_filter(Bp_Filter_t* f)
+{
+    Bp_deallocate_buffers(f);
+}
+
+static void test_generator_sawtooth(void)
+{
+    Bp_Filter_t sink;
+    init_pass_through(&sink);
+
+    Bp_SignalGen_t gen;
+    memset(&gen, 0, sizeof(gen));
+    gen.base.transform = BpSignalGenTransform;
+    gen.base.dtype = DTYPE_UNSIGNED;
+    gen.base.data_width = sizeof(unsigned);
+    gen.waveform = BP_WAVE_SAWTOOTH;
+    gen.amplitude = 256.0f;
+    gen.frequency = 1.0f/256.0f; /* step of 1 per sample */
+    gen.phase = 0.0f;
+    gen.x_offset = 0.0f;
+
+    unsigned out_buf[10] = {0};
+    Bp_Batch_t out_batch = {
+        .head = 0,
+        .tail = 0,
+        .capacity = 10,
+        .t_ns = 0,
+        .period_ns = 1000000u,
+        .dtype = DTYPE_UNSIGNED,
+        .data = out_buf
+    };
+
+    gen.base.transform((Bp_Filter_t*)&gen, &(Bp_Batch_t){0}, &out_batch);
+
+    unsigned exp[10];
+    for(unsigned i=0;i<10;i++)
+        exp[i] = i;
+
+    TEST_ASSERT_EQUAL_UINT(10, out_batch.head);
+    TEST_ASSERT_EQUAL_UINT_ARRAY(exp, out_buf, 10);
+
+    free_filter(&sink);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_generator_sawtooth);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- implement `signal_gen` module with square/sine/triangle/sawtooth generator
- add new `test_signal_gen` unity test
- compile/link using math library

## Testing
- `make all` builds both unit tests
- `./test_core_filter`
- `./test_signal_gen`


------
https://chatgpt.com/codex/tasks/task_e_68526bd9abc48330a2552a93d1c91547