### PR TITLE
Add completion sentinel handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 tests/test_core_filter
 tests/test_signal_gen
+tests/test_sentinel

--- a/bpipe/core.c
+++ b/bpipe/core.c
@@ -8,32 +8,46 @@ const size_t _data_size_lut[] = {
 };
 
 void* Bp_Worker(void* filter) {
-	Bp_Filter_t* f = (Bp_Filter_t*)filter;
-	Bp_Batch_t input_batch = f->has_input_buffer ? Bp_head(f)       : (Bp_Batch_t){ .data = NULL, .capacity = 0, .ec=Bp_EC_NOINPUT};
-	Bp_Batch_t output_batch = f->sink ? Bp_allocate(f->sink) : (Bp_Batch_t){ .data = malloc(1024 * f->data_width), .capacity = 1024 };
+        Bp_Filter_t* f = (Bp_Filter_t*)filter;
+        Bp_Batch_t input_batch = f->has_input_buffer ? Bp_head(f)
+                                                     : (Bp_Batch_t){ .data = NULL, .capacity = 0, .ec=Bp_EC_NOINPUT };
+        Bp_Batch_t output_batch = f->sink ? Bp_allocate(f->sink)
+                                         : (Bp_Batch_t){ .data = malloc(1024 * f->data_width), .capacity = 1024 };
 
-	while (f->running) {
-		f->transform(filter, &input_batch, &output_batch);
+        if (f->has_input_buffer && input_batch.ec == Bp_EC_COMPLETE)
+                f->running = false;
 
-		if (f->has_input_buffer && (input_batch.head >= input_batch.capacity)) {
-			Bp_delete_tail(f);
-			input_batch = Bp_head(f);
-		}
+        while (f->running) {
+                f->transform(filter, &input_batch, &output_batch);
+
+                if (f->has_input_buffer && (input_batch.head >= input_batch.capacity)) {
+                        Bp_delete_tail(f);
+                        input_batch = Bp_head(f);
+                        if (input_batch.ec == Bp_EC_COMPLETE) {
+                                f->running = false;
+                                break;
+                        }
+                }
 		assert(output_batch.head <= output_batch.capacity);
 		assert(output_batch.tail <= output_batch.capacity);
 		assert(output_batch.tail <= output_batch.head);
 
-		if (output_batch.head >= output_batch.capacity) {
-			if (f->sink) {
-				Bp_submit_batch(f->sink, &output_batch);
-				output_batch = Bp_allocate(f->sink);
-			} else {
-				output_batch.head = 0;
-				output_batch.tail = 0;
-			}
-		}
-	}
-	return NULL;
+                if (output_batch.head >= output_batch.capacity) {
+                        if (f->sink) {
+                                Bp_submit_batch(f->sink, &output_batch);
+                                output_batch = Bp_allocate(f->sink);
+                        } else {
+                                output_batch.head = 0;
+                                output_batch.tail = 0;
+                        }
+                }
+        }
+
+        if (f->sink) {
+                Bp_Batch_t done = { .ec = Bp_EC_COMPLETE };
+                Bp_submit_batch(f->sink, &done);
+        }
+        return NULL;
 }
 
 

--- a/bpipe/core.h
+++ b/bpipe/core.h
@@ -30,25 +30,28 @@ typedef enum _SampleType {
 extern const size_t _data_size_lut[];
 
 typedef enum _Bp_EC {
-	Bp_EC_OK = 0,
-	Bp_EC_TIMEOUT = -1,
-	Bp_EC_NOINPUT = -2,
-	Bp_EC_NOSPACE = -3,
-	EC_TYPE_MISMATCH = -4,
-	Bp_EC_BAD_PYOBJECT = -5,
+        Bp_EC_OK = 0,
+        Bp_EC_TIMEOUT = -1,
+        Bp_EC_NOINPUT = -2,
+        Bp_EC_NOSPACE = -3,
+        EC_TYPE_MISMATCH = -4,
+        Bp_EC_BAD_PYOBJECT = -5,
+        /* Stream termination sentinel */
+        Bp_EC_COMPLETE = 1,
 } Bp_EC;
 
 typedef struct _Batch {
-	size_t head;
-	size_t tail;
-	int capacity;
-	long long t_ns;
-	unsigned period_ns;
-	size_t batch_id;
-	Bp_EC ec;
-	void* meta;
-	SampleDtype_t dtype;
-	void* data;
+        size_t head;
+        size_t tail;
+        int capacity;
+        long long t_ns;
+        unsigned period_ns;
+        size_t batch_id;
+        /* Error code or control indicator. Use Bp_EC_COMPLETE to signal end of stream */
+        Bp_EC ec;
+        void* meta;
+        SampleDtype_t dtype;
+        void* data;
 } Bp_Batch_t;
 
 /* Forward declarations */
@@ -229,6 +232,9 @@ static inline Bp_Batch_t Bp_head(Bp_Filter_t* dpipe) {
 }
 
 static inline void Bp_delete_tail(Bp_Filter_t* dpipe) {
-	atomic_fetch_add(&dpipe->n_out, 1);
-	pthread_cond_signal(&dpipe->cond_not_full);
+        atomic_fetch_add(&dpipe->n_out, 1);
+        pthread_cond_signal(&dpipe->cond_not_full);
 }
+
+/* Worker thread entry point */
+void* Bp_Worker(void* filter);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -pthread -lm
 
 SRC = ../bpipe/core.c ../bpipe/signal_gen.c
 
-all: test_core_filter test_signal_gen
+all: test_core_filter test_signal_gen test_sentinel
 
 # existing test
 TEST_CORE = test_core_filter.c
@@ -25,4 +25,12 @@ run_gen: test_signal_gen
 	./test_signal_gen
 
 clean:
-	rm -f test_core_filter test_signal_gen
+	rm -f test_core_filter test_signal_gen test_sentinel
+
+TEST_SENTINEL = test_sentinel.c
+
+test_sentinel: $(SRC) $(TEST_SENTINEL)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+run_sentinel: test_sentinel
+	./test_sentinel

--- a/tests/test_sentinel.c
+++ b/tests/test_sentinel.c
@@ -1,0 +1,64 @@
+#include "../bpipe/core.h"
+#include "unity.h"
+#include <pthread.h>
+#include <string.h>
+
+static void init_filter(Bp_Filter_t* f)
+{
+    memset(f, 0, sizeof(*f));
+    f->transform = BpPassThroughTransform;
+    f->ring_capacity_expo = 2;
+    f->batch_capacity_expo = 2;
+    f->dtype = DTYPE_UNSIGNED;
+    f->data_width = sizeof(unsigned);
+    f->modulo_mask = (1u << f->ring_capacity_expo) - 1u;
+    f->has_input_buffer = true;
+    f->timeout.tv_sec = 1;
+    f->timeout.tv_nsec = 0;
+    pthread_mutex_init(&f->cond_mutex, NULL);
+    pthread_cond_init(&f->cond_not_full, NULL);
+    pthread_cond_init(&f->cond_not_empty, NULL);
+    Bp_allocate_buffers(f);
+}
+
+static void free_filter(Bp_Filter_t* f)
+{
+    Bp_deallocate_buffers(f);
+}
+
+static void test_sentinel_propagation(void)
+{
+    Bp_Filter_t a, b;
+    init_filter(&a);
+    init_filter(&b);
+
+    a.sink = &b;
+
+    a.running = true;
+    b.running = true;
+
+    pthread_create(&b.worker_thread, NULL, Bp_Worker, &b);
+    pthread_create(&a.worker_thread, NULL, Bp_Worker, &a);
+
+    Bp_Batch_t done = { .ec = Bp_EC_COMPLETE };
+    Bp_submit_batch(&a, &done);
+
+    pthread_join(a.worker_thread, NULL);
+    pthread_join(b.worker_thread, NULL);
+
+    TEST_ASSERT_TRUE(!a.running);
+    TEST_ASSERT_TRUE(!b.running);
+
+    Bp_Batch_t rx = Bp_head(&b);
+    TEST_ASSERT_EQUAL_UINT(Bp_EC_COMPLETE, rx.ec);
+
+    free_filter(&a);
+    free_filter(&b);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_sentinel_propagation);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add `Bp_EC_COMPLETE` to error codes
- handle completion sentinel in `Bp_Worker`
- propagate sentinel downstream when workers exit
- add new sentinel-propagation unit test
- ignore compiled sentinel test binary

## Testing
- `cd tests && make clean && make && ./test_core_filter && ./test_signal_gen && ./test_sentinel`

------
https://chatgpt.com/codex/tasks/task_e_68531cb0e6888330a284138c1d5fdc72